### PR TITLE
Bump jacoco-maven-plugin to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.7.5.201505241946</version>
+					<version>0.8.0</version>
 				</plugin>
 				
 				<!-- Mycila -->


### PR DESCRIPTION
New version excludes private empty no-arg constructors from coverage metrics (jacoco/jacoco@c63563d1).